### PR TITLE
Add streamlit video cutter

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,29 @@
-Lib, app, and cite for simple video cutting
+# Video Cutter
+
+This repo contains a small library and interface for cutting pieces of a video or audio file and joining them together without re‑encoding. `ffmpeg` is used under the hood.
+
+## Library Usage
+
+```
+from video_cutter.utils import cut_segments, join_segments
+
+segments = [(0, 5), (10, 15)]
+seg_files = cut_segments('input.mp4', segments, 'tmp')
+join_segments(seg_files, 'output.mp4')
+```
+
+## CLI
+
+```
+python -m video_cutter.cli input.mp4 output.mp4 0-5 10-15
+```
+
+## Web Interface
+
+Run the Streamlit app:
+
+```
+streamlit run app.py
+```
+
+Upload a file, choose segments, and download the result.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+from typing import List, Tuple
+
+import streamlit as st
+
+from video_cutter.utils import cut_segments, join_segments
+
+st.title("Video Cutter")
+
+uploaded_file = st.file_uploader("Choose a video or audio file", type=["mp4", "mov", "mkv", "mp3", "wav"])
+
+if uploaded_file is not None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(uploaded_file.name)[1]) as input_tmp:
+        input_tmp.write(uploaded_file.read())
+        input_path = input_tmp.name
+
+    segments: List[Tuple[float, float]] = []
+    st.write("Enter segments as start and end times in seconds")
+    count = st.number_input("Number of segments", min_value=1, step=1, value=1)
+    for i in range(int(count)):
+        start = st.number_input(f"Segment {i+1} start", min_value=0.0, step=0.1)
+        end = st.number_input(f"Segment {i+1} end", min_value=0.0, step=0.1)
+        segments.append((start, end))
+
+    output = st.text_input("Output filename", "output.mp4")
+
+    if st.button("Cut and Join"):
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                seg_files = cut_segments(input_path, segments, tmpdir)
+                output_path = os.path.join(tmpdir, output)
+                join_segments(seg_files, output_path)
+                with open(output_path, "rb") as f:
+                    st.download_button("Download", f, file_name=output)
+        except Exception as exc:
+            st.error(str(exc))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "video_cutter"
+version = "0.1.0"
+dependencies = [
+    "streamlit",
+]

--- a/video_cutter/__init__.py
+++ b/video_cutter/__init__.py
@@ -1,0 +1,2 @@
+from .utils import cut_segments, join_segments
+__all__ = ["cut_segments", "join_segments"]

--- a/video_cutter/__main__.py
+++ b/video_cutter/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/video_cutter/cli.py
+++ b/video_cutter/cli.py
@@ -1,0 +1,37 @@
+import argparse
+import tempfile
+from typing import List, Tuple
+
+from .utils import cut_segments, join_segments
+
+
+def parse_segments(segment_strs: List[str]) -> List[Tuple[float, float]]:
+    segments: List[Tuple[float, float]] = []
+    for item in segment_strs:
+        parts = item.split('-')
+        if len(parts) != 2:
+            raise ValueError(f"Invalid segment '{item}'. Use start-end")
+        start, end = map(float, parts)
+        segments.append((start, end))
+    return segments
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Cut and join video segments without re-encoding")
+    parser.add_argument("input", help="Input video file")
+    parser.add_argument("output", help="Output file")
+    parser.add_argument(
+        "segments",
+        nargs='+',
+        help="Segments to cut in format start-end (seconds)",
+    )
+    args = parser.parse_args()
+
+    segments = parse_segments(args.segments)
+    with tempfile.TemporaryDirectory() as tmp:
+        seg_files = cut_segments(args.input, segments, tmp)
+        join_segments(seg_files, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/video_cutter/utils.py
+++ b/video_cutter/utils.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+from typing import List, Tuple
+
+
+def run_ffmpeg(args: List[str]) -> None:
+    """Run ffmpeg command and raise RuntimeError on failure."""
+    result = subprocess.run(
+        ["ffmpeg", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stdout)
+
+
+def cut_segments(input_file: str, segments: List[Tuple[float, float]], temp_dir: str) -> List[str]:
+    """Cut segments from input_file and return list of paths to segment files."""
+    if not os.path.exists(input_file):
+        raise FileNotFoundError(f"Input file {input_file} not found")
+
+    os.makedirs(temp_dir, exist_ok=True)
+    segment_files = []
+    for idx, (start, end) in enumerate(segments):
+        if start >= end:
+            raise ValueError(f"Segment {idx} start >= end")
+        output = os.path.join(temp_dir, f"segment_{idx}.mp4")
+        args = [
+            "-y",
+            "-ss",
+            str(start),
+            "-to",
+            str(end),
+            "-i",
+            input_file,
+            "-c",
+            "copy",
+            "-avoid_negative_ts",
+            "make_zero",
+            output,
+        ]
+        run_ffmpeg(args)
+        segment_files.append(output)
+    return segment_files
+
+
+def join_segments(segment_files: List[str], output_file: str) -> None:
+    """Join segments using ffmpeg concat demuxer."""
+    concat_list = os.path.join(os.path.dirname(output_file), "concat.txt")
+    with open(concat_list, "w", encoding="utf-8") as f:
+        for path in segment_files:
+            f.write(f"file '{path}'\n")
+
+    args = [
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        concat_list,
+        "-c",
+        "copy",
+        output_file,
+    ]
+    run_ffmpeg(args)
+


### PR DESCRIPTION
## Summary
- implement ffmpeg helpers for cutting and joining files without re‑encoding
- provide CLI entry point
- add simple Streamlit UI for uploading a file and selecting time ranges
- document usage
- add project metadata

## Testing
- `python3 -m py_compile app.py video_cutter/*.py`
- `pytest -q`
- `python3 -m video_cutter.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_6842d222c168832fa8fc4b7398c909f0